### PR TITLE
feat: Manage tab in the middle, Update Date (max 2) and release payme…

### DIFF
--- a/frontend/src/components/task/TaskManageForm.vue
+++ b/frontend/src/components/task/TaskManageForm.vue
@@ -3,49 +3,134 @@
     <form class="component-card p-6 space-y-4" @submit.prevent>
       <h2 class="title mb-2">Gestionar Tarea</h2>
       <div class="form-group">
-        <label for="taskName" class="form-label required">Nombre de la Tarea</label>
-        <input id="taskName" v-model="form.taskName" type="text" class="form-input" placeholder="Ingresa el nombre de la tarea" required />
+        <label for="escrowId" class="form-label required">ID de la Tarea</label>
+        <input
+          id="escrowId"
+          v-model="form.escrowId"
+          type="text"
+          class="form-input"
+          placeholder="Ej: 0"
+        />
+      </div>
+      <div v-if="escrowDetails" class="form-group">
+        <label class="form-label">Nombre de la Tarea</label>
+        <p class="form-input bg-secondary/30">{{ escrowDetails.taskDescription || '—' }}</p>
       </div>
       <div class="form-group">
         <label for="zkProof" class="form-label">Prueba Criptográfica (solo para eERC20)</label>
-        <textarea id="zkProof" v-model="form.zkProof" class="form-textarea" rows="4" placeholder="Solo requerido para transacciones privadas con eERC20"></textarea>
+        <textarea
+          id="zkProof"
+          v-model="form.zkProof"
+          class="form-textarea"
+          rows="4"
+          placeholder="Solo requerido para transacciones privadas con eERC20"
+        ></textarea>
       </div>
       <div class="flex justify-start w-full">
-        <button type="button" class="btn-secundary !w-40" :disabled="loading" @click="onGoToChat">Ir al Chat</button>
+        <button type="button" class="btn-secundary !w-40" :disabled="loading" @click="onGoToChat">
+          Ir al Chat
+        </button>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
         <button type="button" class="btn-secundary" :disabled="loading" @click="onMarkCompleted">
           Marcar Completada
         </button>
-        <button type="button" class="btn-secundary" :disabled="loading" @click="onReleaseFunds">
-          Liberar Pago
+        <button
+          v-if="isDepositor"
+          type="button"
+          class="btn-secundary"
+          :disabled="loading || !canUpdateDate"
+          :title="!canUpdateDate ? `Máximo ${maxDeadlineUpdates} actualizaciones por tarea` : undefined"
+          @click="onUpdateDate"
+        >
+          Actualizar Fecha
+        </button>
+        <button
+          type="button"
+          class="btn-secundary"
+          :disabled="loading || !form.escrowId"
+          @click="onConfirmReleaseOrExecute"
+        >
+          {{ releaseButtonLabel }}
         </button>
         <button type="button" class="btn-secundary" :disabled="loading" @click="onCancelEscrow">
           Cancelar Tarea
         </button>
       </div>
+      <p v-if="releaseHint" class="text-sm text-textSecondary mt-2">{{ releaseHint }}</p>
     </form>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
-const emit = defineEmits(['markCompleted', 'releaseFunds', 'cancelEscrow'])
-const props = defineProps<{ loading?: boolean }>()
+import type { EscrowDetails } from '../../services/web3'
+
+interface TaskMetaForEscrow {
+  deadlineUpdates?: number
+  depositorReleaseConfirmed?: boolean
+  beneficiaryReleaseConfirmed?: boolean
+}
+
+const props = withDefaults(
+  defineProps<{
+    form: { escrowId: string; zkProof: string }
+    loading?: boolean
+    account: string | null
+    escrowDetails: EscrowDetails | null
+    taskMetaForEscrow?: TaskMetaForEscrow
+    releaseConfirmations: { depositorConfirmed: boolean; beneficiaryConfirmed: boolean }
+    canExecuteRelease: boolean
+  }>(),
+  { loading: false, taskMetaForEscrow: () => ({}) }
+)
+
+const emit = defineEmits<{
+  markCompleted: [payload: { escrowId: string; zkProof: string }]
+  updateDate: [escrowId: number]
+  confirmReleaseOrExecute: [payload: { escrowId: string }]
+  cancelEscrow: [payload: { escrowId: string; zkProof: string }]
+}>()
+
 const router = useRouter()
 
-// MOCK: Datos de prueba y cambio de ID por Nombre para el video
-const form = ref({
-  taskName: 'backend-api',
-  zkProof: '0x2d8a4f6e8d0c2b4a6f8e0d2c4b6a8f0e2d4c6b8a0f2e4d6c8b0a2f4e6d8c0b2a4f6e8d0c2b4a6f8e0d2c4b6a8f0e2d4c6b8a0f2'
+const normalize = (addr: string) => String(addr || '').toLowerCase()
+
+const isDepositor = computed(() => {
+  if (!props.account || !props.escrowDetails) return false
+  return normalize(props.account) === normalize(props.escrowDetails.depositor)
 })
 
-const onMarkCompleted = () => emit('markCompleted', { ...form.value })
-const onReleaseFunds = () => emit('releaseFunds', { ...form.value })
-const onCancelEscrow = () => emit('cancelEscrow', { ...form.value })
+const maxDeadlineUpdates = 2
+const deadlineUpdatesCount = computed(() => props.taskMetaForEscrow?.deadlineUpdates ?? 0)
+const canUpdateDate = computed(() => isDepositor.value && deadlineUpdatesCount.value < maxDeadlineUpdates)
+
+const hasUserConfirmedRelease = computed(() => {
+  if (!props.account || !props.escrowDetails) return false
+  if (isDepositor.value) return props.releaseConfirmations.depositorConfirmed
+  return props.releaseConfirmations.beneficiaryConfirmed
+})
+
+const releaseButtonLabel = computed(() => {
+  if (props.canExecuteRelease) return 'Liberar el Pago'
+  return 'Liberar el Pago'
+})
+
+const releaseHint = computed(() => {
+  if (!props.form.escrowId) return ''
+  if (props.canExecuteRelease) return 'Ambos han confirmado. Al hacer clic se ejecutará la liberación.'
+  if (hasUserConfirmedRelease.value) return 'Esperando que la otra parte también confirme "Liberar el Pago" para ejecutar la liberación.'
+  return 'Ambos (creador y ejecutor) deben confirmar "Liberar el Pago" para ejecutar la liberación.'
+})
+
+const onMarkCompleted = () =>
+  emit('markCompleted', { escrowId: props.form.escrowId, zkProof: props.form.zkProof })
+const onUpdateDate = () => emit('updateDate', Number(props.form.escrowId))
+const onConfirmReleaseOrExecute = () => emit('confirmReleaseOrExecute', { escrowId: props.form.escrowId })
+const onCancelEscrow = () =>
+  emit('cancelEscrow', { escrowId: props.form.escrowId, zkProof: props.form.zkProof })
 const onGoToChat = () => {
-  console.log('Redirecting to chat for task:', form.value.taskName)
   router.push('/chat')
 }
 </script>

--- a/frontend/src/composables/useTaskManager.ts
+++ b/frontend/src/composables/useTaskManager.ts
@@ -5,10 +5,20 @@ import { log } from '../services/logger'
 import { TaskError } from '../services/errors'
 import { CURRENT_NETWORK, NETWORKS } from '../config/index'
 
+const MAX_DEADLINE_UPDATES_PER_TASK = 2
+
 interface TaskMeta {
   timeValue: number
   timeUnit: 'hours' | 'days'
   finishedRequested: boolean
+  /** Veces que el creador actualizó la fecha (máx 2 por tarea) */
+  deadlineUpdates?: number
+  /** Confirmación del depositante para liberar el pago */
+  depositorReleaseConfirmed?: boolean
+  /** Confirmación del beneficiario para liberar el pago */
+  beneficiaryReleaseConfirmed?: boolean
+  /** Fecha fin mostrada tras actualización (solo visual) */
+  customEndDate?: string
 }
 
 export function useTaskManager() {
@@ -131,9 +141,10 @@ export function useTaskManager() {
     localStorage.setItem(TASK_META_KEY, JSON.stringify(taskMeta.value))
   }
 
-  // Tabs
+  // Tabs: Crear | Gestionar | Mis Tareas
   const tabs = [
     { id: 'create', label: 'Crear Tarea', icon: 'fas fa-plus' },
+    { id: 'manage', label: 'Gestionar', icon: 'fas fa-cog' },
     { id: 'list', label: 'Mis Tareas', icon: 'fas fa-list' }
   ]
 
@@ -530,6 +541,102 @@ export function useTaskManager() {
     }
   }
 
+  /** Actualizar fecha de la tarea (solo creador/depositante, máx 2 veces por escrow) */
+  const updateTaskDate = async (escrowId: number) => {
+    if (!authStore.address) return
+    const details = await web3Service.getEscrowDetails(escrowId)
+    const isDepositor = normalizeAddress(authStore.address) === normalizeAddress(details.depositor)
+    if (!isDepositor) {
+      showAlert('error', 'Solo el creador de la tarea puede actualizar la fecha')
+      return
+    }
+    const meta = taskMeta.value[escrowId] || { timeValue: 0, timeUnit: 'days' as const, finishedRequested: false }
+    const count = meta.deadlineUpdates ?? 0
+    if (count >= MAX_DEADLINE_UPDATES_PER_TASK) {
+      showAlert('error', `Solo se puede actualizar la fecha hasta ${MAX_DEADLINE_UPDATES_PER_TASK} veces por tarea`)
+      return
+    }
+    taskMeta.value[escrowId] = { ...meta, deadlineUpdates: count + 1 }
+    saveTaskMeta()
+    showAlert('success', `Fecha actualizada (${count + 1}/${MAX_DEADLINE_UPDATES_PER_TASK}). Queda ${MAX_DEADLINE_UPDATES_PER_TASK - count - 1} actualización(es) para esta tarea.`)
+  }
+
+  /** Confirmaciones para liberar: ambos (A y B) deben confirmar */
+  const getReleaseConfirmations = (escrowId: number) => {
+    const meta = taskMeta.value[escrowId]
+    return {
+      depositorConfirmed: !!meta?.depositorReleaseConfirmed,
+      beneficiaryConfirmed: !!meta?.beneficiaryReleaseConfirmed
+    }
+  }
+
+  const setMyReleaseConfirmation = (escrowId: number) => {
+    const meta = taskMeta.value[escrowId] || { timeValue: 0, timeUnit: 'days' as const, finishedRequested: false }
+    const currentAddress = normalizeAddress(authStore.address)
+    const details = userEscrows.value.find(e => e.id === escrowId)
+    if (!details) return
+    const isDepositor = currentAddress === normalizeAddress(details.depositor)
+    const isBeneficiary = currentAddress === normalizeAddress(details.beneficiary)
+    if (isDepositor) {
+      taskMeta.value[escrowId] = { ...meta, depositorReleaseConfirmed: true }
+    } else if (isBeneficiary) {
+      taskMeta.value[escrowId] = { ...meta, beneficiaryReleaseConfirmed: true }
+    }
+    saveTaskMeta()
+  }
+
+  const canExecuteRelease = (escrowId: number) => {
+    const { depositorConfirmed, beneficiaryConfirmed } = getReleaseConfirmations(escrowId)
+    return depositorConfirmed && beneficiaryConfirmed
+  }
+
+  /** Obtener detalles de un escrow por ID (para Gestionar cuando no está en la lista cargada) */
+  const getEscrowDetailsForManage = async (escrowId: number): Promise<EscrowDetails | null> => {
+    const inList = userEscrows.value.find((e) => e.id === escrowId)
+    if (inList) return inList
+    try {
+      return await web3Service.getEscrowDetails(escrowId)
+    } catch {
+      return null
+    }
+  }
+
+  /** Confirmar liberación (si falta tu confirmación) o ejecutar liberación (si ambos ya confirmaron) */
+  const confirmReleaseOrExecute = async (payload: { escrowId: string }) => {
+    const escrowId = Number(payload.escrowId)
+    if (!payload.escrowId) {
+      showAlert('error', 'Especifique el ID de la tarea')
+      return
+    }
+    let details: EscrowDetails | null = userEscrows.value.find(e => e.id === escrowId) ?? null
+    if (!details) {
+      details = await getEscrowDetailsForManage(escrowId)
+    }
+    if (!details) {
+      showAlert('error', 'No se encontró la tarea con ese ID')
+      return
+    }
+    const currentAddress = normalizeAddress(authStore.address)
+    const isDepositor = currentAddress === normalizeAddress(details.depositor)
+    const isBeneficiary = currentAddress === normalizeAddress(details.beneficiary)
+    if (!isDepositor && !isBeneficiary) {
+      showAlert('error', 'Solo depositante o beneficiario pueden liberar el pago')
+      return
+    }
+    if (canExecuteRelease(escrowId)) {
+      await releaseFunds(payload)
+      return
+    }
+    const meta = taskMeta.value[escrowId] || { timeValue: 0, timeUnit: 'days' as const, finishedRequested: false }
+    const alreadyConfirmed = (isDepositor && meta.depositorReleaseConfirmed) || (isBeneficiary && meta.beneficiaryReleaseConfirmed)
+    if (alreadyConfirmed) {
+      showAlert('info', 'Ya confirmaste. La otra parte debe confirmar también "Liberar el Pago" para ejecutar la liberación.')
+      return
+    }
+    setMyReleaseConfirmation(escrowId)
+    showAlert('success', 'Has confirmado liberar el pago. Cuando la otra parte también confirme, se podrá ejecutar la liberación.')
+  }
+
   const requestTaskFinished = async (escrowId: number) => {
     const current = taskMeta.value[escrowId] || { timeValue: 0, timeUnit: 'days' as const, finishedRequested: false }
     taskMeta.value[escrowId] = {
@@ -764,6 +871,11 @@ export function useTaskManager() {
     markCompleted,
     releaseFunds,
     cancelEscrow,
+    updateTaskDate,
+    getReleaseConfirmations,
+    canExecuteRelease,
+    getEscrowDetailsForManage,
+    confirmReleaseOrExecute,
     requestTaskFinished,
     completeAndRelease,
     loadUserEscrows,

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -56,24 +56,24 @@ export const NETWORKS = {
 } as const
 
 // Current network (can be overridden by environment variable)
-export const CURRENT_NETWORK = (import.meta.env.VITE_NETWORK as keyof typeof NETWORKS) || 'localhost'
+export const CURRENT_NETWORK = (import.meta.env.VITE_NETWORK as keyof typeof NETWORKS) 
 
 // Contract addresses configuration
 export const CONTRACT_CONFIG = {
-  [NETWORKS.localhost.chainId]: {
-    authorization: import.meta.env.VITE_LOCALHOST_AUTH_CONTRACT || '0x5FbDB2315678afecb367f032d93F642f64180aa3',
-    eerc20: import.meta.env.VITE_LOCALHOST_EERC20_CONTRACT || '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
-    registrar: import.meta.env.VITE_LOCALHOST_REGISTRAR_CONTRACT || '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0'
-  },
+  //[NETWORKS.localhost.chainId]: {
+    //authorization: import.meta.env.VITE_LOCALHOST_AUTH_CONTRACT || '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+    //eerc20: import.meta.env.VITE_LOCALHOST_EERC20_CONTRACT || '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
+    //registrar: import.meta.env.VITE_LOCALHOST_REGISTRAR_CONTRACT || '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0'
+  //},
   [NETWORKS.fuji.chainId]: {
-    authorization: import.meta.env.VITE_FUJI_AUTH_CONTRACT || '',
-    eerc20: import.meta.env.VITE_FUJI_EERC20_CONTRACT || '',
-    registrar: import.meta.env.VITE_FUJI_REGISTRAR_CONTRACT || ''
+    authorization: import.meta.env.VITE_FUJI_AUTH_CONTRACT ,
+    eerc20: import.meta.env.VITE_FUJI_EERC20_CONTRACT ,
+    registrar: import.meta.env.VITE_FUJI_REGISTRAR_CONTRACT 
   },
   [NETWORKS.avalanche.chainId]: {
-    authorization: import.meta.env.VITE_AVALANCHE_AUTH_CONTRACT || '',
-    eerc20: import.meta.env.VITE_AVALANCHE_EERC20_CONTRACT || '',
-    registrar: import.meta.env.VITE_AVALANCHE_REGISTRAR_CONTRACT || ''
+    authorization: import.meta.env.VITE_AVALANCHE_AUTH_CONTRACT ,
+    eerc20: import.meta.env.VITE_AVALANCHE_EERC20_CONTRACT ,
+    registrar: import.meta.env.VITE_AVALANCHE_REGISTRAR_CONTRACT 
   }
 } as const
 

--- a/frontend/src/views/TaskManagerView.vue
+++ b/frontend/src/views/TaskManagerView.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import AppHeader from '../components/ui/AppHeader.vue'
 import AppSidebar from '../components/ui/AppSidebar.vue'
 import AlertMessage from '../components/ui/AlertMessage.vue'
 import WalletConnectCard from '../components/ui/WalletConnectCard.vue'
 import TaskCreateForm from '../components/task/TaskCreateForm.vue'
+import TaskManageForm from '../components/task/TaskManageForm.vue'
 import TaskList from '../components/task/TaskList.vue'
 import { useTaskManager } from '../composables/useTaskManager'
 import { useAuthStore } from '../stores/auth'
@@ -20,11 +21,13 @@ const {
   connecting,
   loading,
   creating,
+  managing,
   activeTab,
   isRegisteredForPrivacy,
   alert,
   tabs,
   createForm,
+  manageForm,
   amountUsdEquivalent,
   usdPriceLoading,
   usdPriceSource,
@@ -33,10 +36,58 @@ const {
   connectWallet,
   registerForPrivacy,
   createEscrow,
+  markCompleted,
+  updateTaskDate,
+  confirmReleaseOrExecute,
+  cancelEscrow,
+  getReleaseConfirmations,
+  canExecuteRelease,
+  getEscrowDetailsForManage,
   requestTaskFinished,
   completeAndRelease,
   loadUserEscrows
 } = useTaskManager()
+
+const manageEscrowId = computed(() => {
+  const id = manageForm.value.escrowId
+  const n = Number(id)
+  return Number.isNaN(n) ? null : n
+})
+
+const manageDetailsFetched = ref<import('../services/web3').EscrowDetails | null>(null)
+watch(
+  manageEscrowId,
+  async (id) => {
+    if (id == null) {
+      manageDetailsFetched.value = null
+      return
+    }
+    manageDetailsFetched.value = await getEscrowDetailsForManage(id)
+  },
+  { immediate: true }
+)
+
+const manageEscrowDetails = computed(() => {
+  if (manageEscrowId.value == null) return null
+  return (
+    userEscrows.value.find((e) => e.id === manageEscrowId.value) ?? manageDetailsFetched.value ?? null
+  )
+})
+
+const manageTaskMeta = computed(() => {
+  if (manageEscrowId.value == null) return undefined
+  return taskMeta.value[manageEscrowId.value]
+})
+
+const manageReleaseConfirmations = computed(() => {
+  if (manageEscrowId.value == null) return { depositorConfirmed: false, beneficiaryConfirmed: false }
+  return getReleaseConfirmations(manageEscrowId.value)
+})
+
+const manageCanExecuteRelease = computed(() => {
+  if (manageEscrowId.value == null) return false
+  return canExecuteRelease(manageEscrowId.value)
+})
 
 const shortAddress = computed(() => {
   const addr = account.value
@@ -113,6 +164,20 @@ const handleCreateEscrow = async () => {
                 :usd-price-loading="usdPriceLoading"
                 :usd-price-source="usdPriceSource"
                 @submit="handleCreateEscrow"
+              />
+              <TaskManageForm
+                v-if="activeTab === 'manage'"
+                :form="manageForm"
+                :loading="managing"
+                :account="account"
+                :escrow-details="manageEscrowDetails"
+                :task-meta-for-escrow="manageTaskMeta"
+                :release-confirmations="manageReleaseConfirmations"
+                :can-execute-release="manageCanExecuteRelease"
+                @mark-completed="markCompleted"
+                @update-date="updateTaskDate"
+                @confirm-release-or-execute="confirmReleaseOrExecute"
+                @cancel-escrow="cancelEscrow"
               />
               <TaskList
                 v-if="activeTab === 'list'"


### PR DESCRIPTION
…nt with double confirmation
Manage tab in the middle, Update Date (max 2) and release payment with double confirmation
When selecting “Manage”, the management form is displayed with the Task ID and, if applicable, the Task Name (escrow description). If you enter an ID that is not in “My Tasks”, the details will still load using the ID.

2. Update Date Button

Only visible to the task creator (wallet A / depositor).

For each task (same ID), the date can be updated a maximum of 2 times. After that, the button becomes disabled and the corresponding message is shown.

The counter is stored in taskMeta (localStorage) per escrow.

The current contract does not have an on-chain deadline, so the “date update” is recorded on the front-end (counter and messages). If the contract later exposes a deadline function, it can be connected here.

3. Release Payment: Both Must Confirm

Both A (creator) and B (beneficiary) must press “Release Payment” for the release to execute.

Flow:

Each user presses “Release Payment”: the first time it registers their confirmation (stored in taskMeta).

When both have confirmed, the next click on “Release Payment” executes the release transaction in the contract.

Below the button, a text explains the current status:

If your confirmation is still pending

If you already confirmed and are waiting for the other party

Or if both have confirmed and the next click will execute the release